### PR TITLE
add TensorFlow option for GPU has smaller memory

### DIFF
--- a/train.py
+++ b/train.py
@@ -3,6 +3,7 @@ import argparse
 from tools.utils import *
 import os
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+os.environ["TF_FORCE_GPU_ALLOW_GROWTH"]= "true"
 
 """parsing and configuration"""
 


### PR DESCRIPTION
Hi.
I tried train.py on a GPU  with smaller memory. This GPU is RTX 2070 SUPER (8GB).

I got a memory error on line 274 of AnimeGanv2.py even though I set the batch size small.

After investigating, it seems that there is a bug in the memory allocation of Tensorflow.
https://www.reddit.com/r/MachineLearning/comments/ea083i/d_tensorflow_gpu_memory_management_tf_force_gpu/

Therefore, I fixed.

I think it's difficult to reproduce the bug, but I hope it helps someone.Thanks!